### PR TITLE
Add Log Resource Policy

### DIFF
--- a/ecs-stopped-tasks-cwlogs.yaml
+++ b/ecs-stopped-tasks-cwlogs.yaml
@@ -8,7 +8,7 @@ Parameters:
     Default: /aws/events/ECSStoppedTasksEvent
   CWLogGroupRetention:
     Type: Number
-    Description: The number of days to retain the events in the log group
+    Description: "The number of days to retain the events in the log group. Supported values: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653"
     Default: 30
 
 Resources:
@@ -37,3 +37,33 @@ Resources:
     Properties:
       LogGroupName: !Ref CWLogGroupName
       RetentionInDays: !Ref CWLogGroupRetention
+
+  LogGroupEventsPolicy:
+    Type: AWS::Logs::ResourcePolicy
+    Properties:
+      PolicyName: EventBridgeToCWLogsPolicy
+      PolicyDocument: !Sub 
+      - >
+        {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Sid": "EventBridgetoCWLogsPolicy",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "delivery.logs.amazonaws.com",
+                  "events.amazonaws.com"
+                ]
+              },
+              "Action": [
+                "logs:CreateLogStream",
+                "logs:PutLogEvents"
+              ],
+              "Resource": [
+                "${logArn}"
+              ]
+            }
+          ]
+        }
+      - { logArn: !GetAtt LogGroup.Arn }


### PR DESCRIPTION
*Description of changes:*
This CloudFormation only works if the account has an existing Event rule with CloudWatch Logs as a target, which automatically creates the necessary Log Resource policy. Instead of relying on that, which may not exist, I have provided a working resource policy. Policy was pulled from: https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-use-resource-based.html. Lastly, I have updated the description of the LogGroupRetention parameter to show allowed values.